### PR TITLE
Fixing Portfolio filters's Allignment in Mobile View

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -927,6 +927,13 @@ section {
   opacity: 1;
 }
 
+@media (max-width:520px){
+  .portfolio #portfolio-flters{
+    text-align: center;
+    flex-direction: column;
+  }
+}
+
 /*--------------------------------------------------------------
 # Testimonials
 --------------------------------------------------------------*/


### PR DESCRIPTION
**Before:**
Portfolio Filters is not properly visible and accessible in mobile view( after 520px)

 
![healthBliss_before](https://user-images.githubusercontent.com/90257489/144736231-ebcd40a3-aee2-49cf-a5cd-181d43403fdf.JPG)


**After:**
Portfolio filter's direction is now column and aligning in center
![healthBliss_after](https://user-images.githubusercontent.com/90257489/144736272-33846ded-77f5-4028-88a5-65bf2cb4eab2.JPG)


